### PR TITLE
Remove noncanonical definitions.

### DIFF
--- a/Text/Reform/Core.hs
+++ b/Text/Reform/Core.hs
@@ -103,7 +103,6 @@ instance (SG.Semigroup input, Monad m) => SG.Semigroup (Environment m input) whe
 -- | Not quite sure when this is useful and so hard to say if the rules for combining things with Missing/Default are correct
 instance (SG.Semigroup input, Monad m) => Monoid (Environment m input) where
     mempty = NoEnvironment
-    mappend = (SG.<>)
 
 -- | Utility function: returns the current 'FormId'. This will only make sense
 -- if the form is not composed

--- a/Text/Reform/Result.hs
+++ b/Text/Reform/Result.hs
@@ -31,7 +31,6 @@ instance Functor (Result e) where
     fmap f (Ok x)    = Ok (f x)
 
 instance Monad (Result e) where
-    return = Ok
     Error x >>= _ = Error x
     Ok x    >>= f = f x
 


### PR DESCRIPTION
This appeases the `-Wnoncanonical-monad-instances` warning. A future GHC release will treat noncanonical definitions as errors. See https://github.com/haskell/core-libraries-committee/issues/328.